### PR TITLE
Fix initial path handling in repository creation

### DIFF
--- a/app/src/ui/add-repository/create-repository.tsx
+++ b/app/src/ui/add-repository/create-repository.tsx
@@ -121,7 +121,14 @@ export class CreateRepository extends React.Component<
   public constructor(props: ICreateRepositoryProps) {
     super(props)
 
-    const path = this.props.initialPath ? this.props.initialPath : null
+    // If there is an initial path, remove the last part of the path which will
+    // be the suggested repository name. For example, if the initial path is
+    // /Users/adam/Projects/MyProject, the path will be /Users/adam/Projects and
+    // the name will be MyProject, so the repository will be created at
+    // /Users/adam/Projects/MyProject.
+    const path = this.props.initialPath
+      ? Path.dirname(this.props.initialPath)
+      : null
 
     const name = this.props.initialPath
       ? sanitizedRepositoryName(Path.basename(this.props.initialPath))


### PR DESCRIPTION
Updated the logic to correctly derive the repository path and name from the initial path. The change ensures that the last part of the initial path is treated as the repository name, and the parent directory is used as the path.

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
-

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
