### PR TITLE
Refactor state initialization in RefNameTextBox

### DIFF
--- a/app/src/ui/lib/ref-name-text-box.tsx
+++ b/app/src/ui/lib/ref-name-text-box.tsx
@@ -65,10 +65,12 @@ export class RefNameTextBox extends React.Component<
 
   public constructor(props: IRefNameProps) {
     super(props)
+    this.state = this.getStateForInitialValue(props.initialValue)
+  }
 
-    const proposedValue = props.initialValue || ''
-
-    this.state = {
+  private getStateForInitialValue(initialValue?: string): IRefNameState {
+    const proposedValue = initialValue || ''
+    return {
       proposedValue,
       sanitizedValue: sanitizedRefName(proposedValue),
     }
@@ -80,6 +82,15 @@ export class RefNameTextBox extends React.Component<
       this.props.onValueChange !== undefined
     ) {
       this.props.onValueChange(this.state.sanitizedValue)
+    }
+  }
+
+  public componentWillReceiveProps(nextProps: IRefNameProps): void {
+    if (
+      nextProps.initialValue !== this.props.initialValue &&
+      this.state.sanitizedValue === ''
+    ) {
+      this.setState(this.getStateForInitialValue(nextProps.initialValue))
     }
   }
 


### PR DESCRIPTION
Moved state initialization logic to a new helper method `getStateForInitialValue` for better reusability. Added `componentWillReceiveProps` to update state when `initialValue` changes and the sanitized value is empty.

<!--
What GitHub Desktop issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #[issue number]

## Description
<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->
-

### Screenshots

<!--
If this PR touches the UI layer of the app, please include screenshots or animated gifs to show the changes.
-->

## Release notes

<!--
You can leave this blank if you're not sure.
If you don't believe this PR needs to be mentioned in the release notes, write "Notes: no-notes".
-->

Notes:
